### PR TITLE
Stop attempting to overwrite read-only files

### DIFF
--- a/pulse/core/git/git_download.py
+++ b/pulse/core/git/git_download.py
@@ -91,7 +91,10 @@ def download_package(
 ) -> None:
     os.makedirs(package_path, exist_ok=True)
     package_dir = os.path.join(package_path, version)
+
     if not is_commit:
+        if os.path.exists(package_dir):
+            shutil.rmtree(package_dir)
         Repo.clone_from(
             f"https://github.com/{owner}/{repo}.git",
             package_dir,
@@ -99,6 +102,8 @@ def download_package(
             branch=version,
         )
     else:
+        if os.path.exists(package_dir):
+            shutil.rmtree(package_dir)
         git_repo = Repo.clone_from(
             f"https://github.com/{owner}/{repo}.git", package_dir, single_branch=True
         )
@@ -111,6 +116,8 @@ def download_package(
         download_requirements(dependencies)
 
     requirements = os.path.join(REQUIREMENTS_PATH, repo)
+    if os.path.exists(requirements):
+        shutil.rmtree(requirements)
     shutil.copytree(package_dir, requirements, dirs_exist_ok=True)
 
 

--- a/pulse/package/package_ensure.py
+++ b/pulse/package/package_ensure.py
@@ -62,6 +62,8 @@ def ensure_packages() -> None:
             )
 
         ensure_path = os.path.join(REQUIREMENTS_PATH, re_package[1])
+        if os.path.exists(ensure_path):
+            shutil.rmtree(ensure_path)
         shutil.copytree(package_path, ensure_path, dirs_exist_ok=True)
         plugins_path = os.path.join(PLUGINS_PATH, f"{re_package[0]}/{re_package[1]}")
         if os.path.exists(plugins_path):


### PR DESCRIPTION
If we try to overwrite read-only files the operation will fail due to insufficient permissions.
To avoid it, we firstly safely remove the directory if it exists, and then we start copying the files.