### PR TITLE
Add back requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+click==8.1.7
+PyGithub==2.3.0
+Requests==2.32.3
+tomli==2.0.1
+tomli_w==1.0.0


### PR DESCRIPTION
Add back requirements.txt, so people can use pip to install them and get the project running straight from source code.
It might be especially useful if somebody plans to dive into the project and perhaps make some changes to the codebase.

I scanned the project with `pipreqs`, so now this file should contain only the packages that are actually needed.

For reference, the file has been nuked by this commit: 011de39989210a035489fa29121f4893fddda2f9 but as I've stated above, it's needed.