### PR TITLE
Add version flag to the CLI

### DIFF
--- a/pulse/core/core_constants.py
+++ b/pulse/core/core_constants.py
@@ -1,1 +1,2 @@
 STDLIB_NAME: str = "omp-stdlib"
+PROJECT_VERSION: str = 'pulse 0.2.0-alpha'

--- a/pulse/core/core_group.py
+++ b/pulse/core/core_group.py
@@ -11,11 +11,12 @@ from pulse.run.run import run
 from pulse.stroke.stroke import stroke
 from pulse.package.package_pack import package
 from pulse.release.release import release
+import pulse.core.core_constants as core_constants
 
 def print_version(ctx, param, value):
     if not value or ctx.resilient_parsing:
         return
-    click.echo('pulse 0.2.0-alpha')
+    click.echo(core_constants.PROJECT_VERSION)
     ctx.exit()
 
 

--- a/pulse/core/core_group.py
+++ b/pulse/core/core_group.py
@@ -12,8 +12,18 @@ from pulse.stroke.stroke import stroke
 from pulse.package.package_pack import package
 from pulse.release.release import release
 
+def print_version(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo('pulse 0.2.0-alpha')
+    ctx.exit()
+
 
 @click.group()
+@click.option('-v', '--version', is_flag=True, callback=print_version,
+              expose_value=False, is_eager=True,
+              help="Show the version and exit.")
+
 def pulse() -> None:
     """Pulse - Your open.mp package manager and build tools.
 
@@ -21,7 +31,6 @@ def pulse() -> None:
         None
     """
     ...
-
 
 pulse.add_command(init)
 pulse.add_command(configure)


### PR DESCRIPTION
Add a way to print currently installed version. It has to be bumped manually each release.

This lets us to later on create systems to automatically update the package only if it's necessary or create update checks within the program itself that base on this version and e.g. comparing it to latest GitHub release by using curl (in shell scripting something like `curl -s https://api.github.com/repos/pulsepm/pulse/releases | grep -Po '"tag_name": "\K.*?(?=")'`).

This will also help my Linux installer script determinate currently installed version.