### PR TITLE
Switch from toml to tomli in the converter

### DIFF
--- a/pulse/run/run_convert.py
+++ b/pulse/run/run_convert.py
@@ -1,11 +1,11 @@
 import os
 import json
-import toml
+import tomli
 
 def config_convert(toml_file_path: str, json_file_path: str):
     
     with open(toml_file_path, 'r') as file:
-        config = toml.load(file)
+        config = tomli.load(file)
 
     config_profile = config.get('runtime', {})
 


### PR DESCRIPTION
Everywhere in the project we use `tomli` instead of `toml`, it makes no sense to use the latter package here.
Must be an accidental mistake. 