### PR TITLE
Create install script for Linux and add Linux install instructions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,15 +19,20 @@ get_download_url() {
 check_and_update() {
     local current_version
     local latest_version
-    current_version=$(pulse -v 2>&1 >/dev/null | awk '{print $2}')
-    latest_version=$(get_latest_version)
+    current_version=$(pulse -v 2>/dev/null | awk '{print $2}')
     
-    if [[ "${current_version}" != "${latest_version}" ]]; then
-        echo "Updating pulse from ${current_version} to ${latest_version}"
+    if [[ -z "${current_version}" ]]; then
+        echo "Could not determine the current version of pulse. Assuming update is needed."
         return 0
     else
-        echo "Pulse is already up to date (version ${current_version})."
-        return 1
+        latest_version=$(set -e; get_latest_version)
+        if [[ "${current_version}" != "${latest_version}" ]]; then
+            echo "Updating pulse from ${current_version} to ${latest_version}"
+            return 0
+        else
+            echo "Pulse is already up to date (version ${current_version})."
+            return 1
+        fi
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ get_download_url() {
 check_and_update() {
     local current_version
     local latest_version
-    current_version=$(pulse -v | awk '{print $2}')
+    current_version=$(pulse -v 2>&1 >/dev/null | awk '{print $2}')
     latest_version=$(get_latest_version)
     
     if [[ "${current_version}" != "${latest_version}" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+readonly API_URL="https://api.github.com/repos/pulsepm/pulse/releases"
+readonly BINARY_NAME="pulse"
+readonly INSTALL_DIR="${HOME}/.local/bin"
+readonly BINARY_PATH="${INSTALL_DIR}/${BINARY_NAME}"
+
+get_latest_version() {
+    curl -s "${API_URL}" | grep -m1 -Po '"tag_name": "\K.*?(?=")'
+}
+
+get_download_url() {
+    curl -s "${API_URL}" | grep -m1 -Po '"browser_download_url": "\K.*pulse(?=")'
+}
+
+check_and_update() {
+    local current_version
+    local latest_version
+    current_version=$(pulse -v | awk '{print $2}')
+    latest_version=$(get_latest_version)
+    
+    if [[ "${current_version}" != "${latest_version}" ]]; then
+        echo "Updating pulse from ${current_version} to ${latest_version}"
+        return 0
+    else
+        echo "Pulse is already up to date (version ${current_version})."
+        return 1
+    fi
+}
+
+download_and_install() {
+    local download_url
+    download_url=$(get_download_url)
+    echo "Downloading pulse binary from ${download_url}"
+    
+    if ! curl -L -o "${BINARY_PATH}" "${download_url}"; then
+        echo "Download failed. Please check your internet connection and try again." >&2
+        exit 1
+    fi
+    
+    chmod u+x "${BINARY_PATH}"
+}
+
+update_path() {
+    local config_file
+    case "${SHELL}" in
+        */bash)
+            config_file="${HOME}/.bashrc"
+            ;;
+        */zsh)
+            config_file="${HOME}/.zshrc"
+            ;;
+        *)
+            config_file="${HOME}/.profile"
+            ;;
+    esac
+    
+    if [[ ":${PATH}:" != *":${INSTALL_DIR}:"* ]]; then
+        echo "Adding ${INSTALL_DIR} to PATH in ${config_file}"
+        echo "export PATH=\$PATH:${INSTALL_DIR}" >> "${config_file}"
+    fi
+}
+
+list_dependencies() {
+    echo "This script requires the following dependencies:"
+    echo "- curl: for downloading files and interacting with the GitHub API"
+    echo "- grep: for parsing command output"
+    echo "- awk: for text processing"
+    echo "Please ensure these are installed on your system."
+}
+
+main() {
+    local is_fresh_install=true
+
+    if command -v pulse &> /dev/null; then
+        is_fresh_install=false
+        echo "Existing pulse installation found. Checking for updates..."
+        if ! check_and_update; then
+            exit 0
+        fi
+    fi
+
+    # Create the ~/.local/bin directory and add to $PATH if it's not there
+    mkdir -p "${INSTALL_DIR}"
+    
+    if ${is_fresh_install}; then
+        update_path
+    fi
+    
+    if ! download_and_install; then
+        echo "Installation failed. Please check your permissions and try again." >&2
+        list_dependencies
+        exit 1
+    fi
+    
+    if command -v pulse &> /dev/null; then
+        if ${is_fresh_install}; then
+            echo "Pulse has been successfully installed and added to your PATH."
+            echo "You may need to restart your shell or source your shell configuration file for PATH changes to take effect."
+        else
+            echo "Pulse has been successfully updated."
+        fi
+    else
+        echo "Installation failed. Please check your permissions and try again." >&2
+        list_dependencies
+        exit 1
+    fi
+}
+
+main "$@"
+

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,56 @@ Pulse Package Manager (PPM) is a comprehensive package manager designed specific
 - **Automatic Dependency Resolution**: Automatically resolve and install dependencies for added packages, reducing manual effort and ensuring consistency across environments.
 - **Project Initialization**: Initialize new open.mp projects with user-defined settings and configurations, streamlining the setup process for new development endeavors.
 
+## Installation and Updating
+### Linux
+#### Install Script (Recommended)
+Execute the script to install (or update if necessary) `pulse`.
+```sh
+curl -sSL https://raw.githubusercontent.com/pulsepm/pulse/main/install.sh | bash
+```
+
+### Manual Installation
+1. Download the latest version of pulse from our [releases](https://github.com/pulsepm/pulse/releases).
+
+2. Mark the downloaded binary as executable:
+```sh
+chmod u+x pulse
+```
+
+3. (Optional) Move it to a location that's defined in your `$PATH`:
+```sh
+mv pulse /usr/local/bin/ # sudo permissions are required by this specific path
+```
+
+### Development Installation
+To set up a development environment, ensure you have `pip` installed (it may be packaged as `pip` or `pip3` on your system).
+
+1. Clone the repository:
+```sh
+git clone https://github.com/pulsepm/pulse
+```
+
+2. Navigate to the project directory:
+```sh
+cd pulse
+```
+
+3. Create and activate a virtual environment:
+```sh
+virtualenv venv --distribute && source venv/bin/activate
+```
+
+4. Install the required dependencies:
+```sh
+pip install -r requirements.txt
+```
+
+5. (Optional) Create a script for easier launching pulse
+Make sure `~/.local/bin` is in your `$PATH`.
+```sh
+echo "python3 $(pwd)/pulse.py \"\$@\"" > ~/.local/bin/pulse && chmod u+x ~/.local/bin/pulse
+```
+
 ## Contributing
 
 Contributions to Pulse Package Manager are welcome! If you encounter any issues or have suggestions for improvement, please feel free to open an issue or submit a pull request on the GitHub repository.
@@ -182,9 +232,7 @@ Ensures all packages are present.
 #### Behavior:
 The `pulse ensure` command reads the packages specified in `project_folder/pulse.toml`, then copies them from the Pulse Package Configuration to `project_folder/requirements` (including plugins, dependencies, etc.). If any packages are not found, they are installed and automatically copied.
 
-##
-
- License
+## License
 
 Pulse Package Manager is licensed under the [MIT License](LICENSE).
 ```

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ curl -sSL https://raw.githubusercontent.com/pulsepm/pulse/main/install.sh | bash
 ```
 
 ### Manual Installation
-1. Download the latest version of pulse from our [releases](https://github.com/pulsepm/pulse/releases).
+1. Download the latest version of Pulse from our [releases](https://github.com/pulsepm/pulse/releases).
 
 2. Mark the downloaded binary as executable:
 ```sh
@@ -34,6 +34,8 @@ mv pulse /usr/local/bin/ # sudo permissions are required by this specific path
 
 ### Development Installation
 To set up a development environment, ensure you have `pip` installed (it may be packaged as `pip` or `pip3` on your system).
+While it's possible to have Pulse working without setting up an virtual environment, it's strongly not recommended.
+If you don't want to bother with virtual environments, you may want to look into [pipx](https://github.com/pypa/pipx).
 
 1. Clone the repository:
 ```sh
@@ -55,7 +57,7 @@ virtualenv venv --distribute && source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-5. (Optional) Create a script for easier launching pulse
+5. (Optional) Create a script for easier launching Pulse
 Make sure `~/.local/bin` is in your `$PATH`.
 ```sh
 echo "python3 $(pwd)/pulse.py \"\$@\"" > ~/.local/bin/pulse && chmod u+x ~/.local/bin/pulse


### PR DESCRIPTION
This script might be a bit over-complicated for its purpose, but I enjoyed creating it. It can install and update Pulse on any Linux distribution, as long as you have GNU versions of `awk`, `bash`, `curl`, and `grep`.

In addition to adding the script, this PR also updates the README with:
1. Multiple instructions on how to get the project running on Linux.
2. A fixed "License" heading (a subtle change not worth a separate PR).

It might also be worthwhile to add a simple way to uninstall everything related to Pulse. This is something I may address in a future PR.

Part of the script relies on the `-v` flag, which I added in the PR #116, so the script is able to update the binary if we're running an outdated version.

The script currently lacks a method to accurately determine the installed version of Pulse. As a result, during the update to the next release, users will see the `Could not determine the current version of pulse. Assuming update is needed.` message.

Moving forward, starting from the subsequent release where version tracking is implemented, updates will display the `Updating pulse from ${current_version} to ${latest_version}` message when updating from that release onwards, which is actually informative.