### PR TITLE
Add the ability to remove Pulse via Install script and switch from curl to wget

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 shopt -s inherit_errexit
 
@@ -9,11 +8,11 @@ readonly INSTALL_DIR="${HOME}/.local/bin"
 readonly BINARY_PATH="${INSTALL_DIR}/${BINARY_NAME}"
 
 get_latest_version() {
-    curl -s "${API_URL}" | grep -m1 -Po '"tag_name": "\K.*?(?=")'
+    wget -qO- "${API_URL}" | grep -m1 -Po '"tag_name": "\K.*?(?=")'
 }
 
 get_download_url() {
-    curl -s "${API_URL}" | grep -m1 -Po '"browser_download_url": "\K.*pulse(?=")'
+    wget -qO- "${API_URL}" | grep -m1 -Po '"browser_download_url": "\K.*pulse(?=")'
 }
 
 check_and_update() {
@@ -41,7 +40,7 @@ download_and_install() {
     download_url=$(get_download_url)
     echo "Downloading pulse binary from ${download_url}"
     
-    if ! curl -L -o "${BINARY_PATH}" "${download_url}"; then
+    if ! wget -q -O "${BINARY_PATH}" "${download_url}"; then
         echo "Download failed. Please check your internet connection and try again." >&2
         exit 1
     fi
@@ -71,7 +70,7 @@ update_path() {
 
 list_dependencies() {
     echo "This script requires the following dependencies:"
-    echo "- curl: for downloading files and interacting with the GitHub API"
+    echo "- wget: for downloading files and interacting with the GitHub API"
     echo "- grep: for parsing command output"
     echo "- awk: for text processing"
     echo "Please ensure these are installed on your system."
@@ -79,7 +78,6 @@ list_dependencies() {
 
 main() {
     local is_fresh_install=true
-
     if command -v pulse &> /dev/null; then
         is_fresh_install=false
         echo "Existing pulse installation found. Checking for updates..."
@@ -87,7 +85,6 @@ main() {
             exit 0
         fi
     fi
-
     # Create the ~/.local/bin directory and add to $PATH if it's not there
     mkdir -p "${INSTALL_DIR}"
     
@@ -116,4 +113,3 @@ main() {
 }
 
 main "$@"
-

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Pulse Package Manager (PPM) is a comprehensive package manager designed specific
 #### Install Script (Recommended)
 Execute the script to install (or update if necessary) `pulse`.
 ```sh
-curl -sSL https://raw.githubusercontent.com/pulsepm/pulse/main/install.sh | bash
+wget -qO- https://raw.githubusercontent.com/pulsepm/pulse/master/install.sh | bash -s
 ```
 
 ### Manual Installation

--- a/readme.md
+++ b/readme.md
@@ -234,6 +234,19 @@ Ensures all packages are present.
 #### Behavior:
 The `pulse ensure` command reads the packages specified in `project_folder/pulse.toml`, then copies them from the Pulse Package Configuration to `project_folder/requirements` (including plugins, dependencies, etc.). If any packages are not found, they are installed and automatically copied.
 
+## Uninstalling Pulse
+### Linux
+To uninstall Pulse and remove only the program binary, execute the following command in your terminal:
+```sh
+wget -qO- https://raw.githubusercontent.com/pulsepm/pulse/master/install.sh | bash -s -- --remove
+```
+
+To completely remove Pulse, including all associated configuration and cache directories, use the --remove-all option:
+```sh
+wget -qO- https://raw.githubusercontent.com/pulsepm/pulse/master/install.sh | bash -s -- --remove-all
+```
+The --remove-all option will delete all files and directories related to Pulse. Ensure you have backed up any important data before proceeding with this command.
+
 ## License
 
 Pulse Package Manager is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
- Switch from `curl` to `wget` as not everyone has curl installed and it should be as easy as possible to get Pulse running
- Add a way to easily uninstall Pulse on Linux
  - `./install.sh --remove` - to remove the executable installed by the script
  - `./install.sh --remove-all` - to remove the executable and all associated directories in the XDG paths 
- Add a help menu to the script (since it now offers more options)
